### PR TITLE
Faster IsExecuteSet check

### DIFF
--- a/patriot.h
+++ b/patriot.h
@@ -71,12 +71,10 @@ static bool inline VirtualProtectFunction(void** functions, int count, DWORD64 f
 
 static bool inline IsExecuteSet(DWORD protect)
 {
-    if ((protect == PAGE_EXECUTE) || (protect == PAGE_EXECUTE_READ) ||
-        (protect == PAGE_EXECUTE_READWRITE) || (protect == PAGE_EXECUTE_WRITECOPY))
+    if( protect & 0xF0 )
     {
         return true;
     }
-
     return false;
 }
 


### PR DESCRIPTION
Faster, semantically same comparison.

```
#define PAGE_EXECUTE            0x10    00010000
#define PAGE_EXECUTE_READ       0x20    00100000
#define PAGE_EXECUTE_READWRITE  0x40    01000000
#define PAGE_EXECUTE_WRITECOPY  0x80    10000000
					11110000 = 0xF0
```